### PR TITLE
fix: Issue 459 (Direct sorts last in nodes list)

### DIFF
--- a/src/components/generic/Table/index.tsx
+++ b/src/components/generic/Table/index.tsx
@@ -13,11 +13,17 @@ export interface Heading {
 }
 
 /**
- * @param hopsAway Number of hops away the node is from the current node
- * @returns number of hopsAway or `0` if hopsAway type is `string`
+ * @param hopsAway String describing the number of hops away the node is from the current node
+ * @returns number of hopsAway or `0` if hopsAway is 'Direct'
  */
-function numericHops(hopsAway: string|number): number {
-  return typeof hopsAway === "string" ? 0 : Number(hopsAway);
+function numericHops(hopsAway: string): number {
+  if(hopsAway.match(/direct/i)){
+    return 0;
+  }
+  if ( hopsAway.match(/\d+\shop/gi) ) {
+    return Number( hopsAway.match(/(\d+)\s+hop/i)?.[1] );
+  }
+  return -1;
 }
 
 export const Table = ({ headings, rows }: TableProps) => {
@@ -56,8 +62,9 @@ export const Table = ({ headings, rows }: TableProps) => {
 
     // Custom comparison for 'Connection' column
     if (sortColumn === "Connection") {
-      const aNumHops = numericHops(aValue.props.hopsAway);
-      const bNumHops = numericHops(bValue.props.hopsAway);
+      //debugger;
+      const aNumHops = numericHops(aValue[0]);
+      const bNumHops = numericHops(bValue[0]);
 
       if (aNumHops < bNumHops) {
         return sortOrder === "asc" ? -1 : 1;

--- a/src/components/generic/Table/index.tsx
+++ b/src/components/generic/Table/index.tsx
@@ -12,6 +12,14 @@ export interface Heading {
   sortable: boolean;
 }
 
+/**
+ * @param hopsAway Number of hops away the node is from the current node
+ * @returns number of hopsAway or `0` if hopsAway type is `string`
+ */
+function numericHops(hopsAway: string|number): number {
+  return typeof hopsAway === "string" ? 0 : Number(hopsAway);
+}
+
 export const Table = ({ headings, rows }: TableProps) => {
   const [sortColumn, setSortColumn] = useState<string | null>("Last Heard");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
@@ -41,6 +49,20 @@ export const Table = ({ headings, rows }: TableProps) => {
         return sortOrder === "asc" ? -1 : 1;
       }
       if (aTimestamp > bTimestamp) {
+        return sortOrder === "asc" ? 1 : -1;
+      }
+      return 0;
+    }
+
+    // Custom comparison for 'Connection' column
+    if (sortColumn === "Connection") {
+      const aNumHops = numericHops(aValue.props.hopsAway);
+      const bNumHops = numericHops(bValue.props.hopsAway);
+
+      if (aNumHops < bNumHops) {
+        return sortOrder === "asc" ? -1 : 1;
+      }
+      if (aNumHops > bNumHops) {
         return sortOrder === "asc" ? 1 : -1;
       }
       return 0;


### PR DESCRIPTION
## Description
This PR addresses the issue outlined in Issue 459 by adding another custom sort to generic Table component (similar to the preceding one in place for "Last heard".)

## Related Issues
Fixes #459

## Changes Made
- Added a [function](https://github.com/bkimmel/meshtastic_web/pull/1/files#diff-4257262cb89f762e7d20df5068ab5d524a5fbe6fa942ae88eca5ffdc44fd1bf4R19) to evaluate the "hopsAway" field for a node and convert it to 0 in the case that it is a string (like "Direct") 
- Added a [column sort](https://github.com/bkimmel/meshtastic_web/compare/master...bkimmel:meshtastic_web:issue459/directsortzero?expand=1#diff-4257262cb89f762e7d20df5068ab5d524a5fbe6fa942ae88eca5ffdc44fd1bf4R57) for "Connection" that takes the function above and uses it to sort the values as appropriate.

## Testing Done
WIP

## Screenshots (if applicable)
Before:
![image](https://github.com/user-attachments/assets/b05ae63c-8390-4b08-9cf5-5a7247ea092d)

After:
![image](https://github.com/user-attachments/assets/596b1242-895c-4fda-9240-c91420e04774)

## Checklist
<!--
Check all that apply. If an item doesn't apply to your PR, you can leave it unchecked or remove it.
-->
- [ ] Code follows project style guidelines
- [ ] Documentation has been updated or added
- [ ] Tests have been added or updated
- [ ] All CI checks pass
- [ ] Dependent changes have been merged

## Additional Notes
<!--
Add any other context about the PR here.
-->